### PR TITLE
Fix numpy.fft import

### DIFF
--- a/dftreg.py
+++ b/dftreg.py
@@ -36,7 +36,7 @@ import time
 try:
     from pyfftw.interfaces.numpy_fft import fftn, ifftn
 except ImportError:
-    from np.fft import fftn, ifftn
+    from numpy.fft import fftn, ifftn
     print('dftreg: pyfftw not found, using numpy fft instead')
 
 


### PR DESCRIPTION
Importing np.fft requires spelling out the full module name
